### PR TITLE
[INFRA-1521] Limit output of heal info

### DIFF
--- a/pkg/glusterutils/healinfo_gd1.go
+++ b/pkg/glusterutils/healinfo_gd1.go
@@ -40,7 +40,7 @@ func (g *GD1) getHealDetails(cmd string) ([]HealEntry, error) {
 // HealInfo gets gluster vol heal info (GD1)
 func (g GD1) HealInfo(vol string) ([]HealEntry, error) {
 	// Get the overall heal count
-	cmd := fmt.Sprintf("vol heal %s events info  | head -1000 | grep \"<gfid:\" | wc -l", vol)
+	cmd := fmt.Sprintf("vol heal %s events info | head -1000 | grep \"<gfid:\" | wc -l", vol)
 	heals, err := g.getHealDetails(cmd)
 	if err != nil {
 		return nil, err

--- a/pkg/glusterutils/healinfo_gd1.go
+++ b/pkg/glusterutils/healinfo_gd1.go
@@ -40,7 +40,7 @@ func (g *GD1) getHealDetails(cmd string) ([]HealEntry, error) {
 // HealInfo gets gluster vol heal info (GD1)
 func (g GD1) HealInfo(vol string) ([]HealEntry, error) {
 	// Get the overall heal count
-	cmd := fmt.Sprintf("vol heal %s info", vol)
+	cmd := fmt.Sprintf("vol heal %s events info  | head -1000 | grep \"<gfid:\" | wc -l", vol)
 	heals, err := g.getHealDetails(cmd)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Forked in response to:

I’m a bit worried that this doesn’t limit the output: https://github.com/gluster/gluster-prometheus/blob/3c54c4d50006f47c6b309415b1c9bab1e7ad3989/pkg/glusterutils/healinfo_gd1.go#L43

This means when a node goes down and you have 10s of thousands of these it will never return any metrics.

As discussed before, we only really care about events where the gfid is displayed as this means they are stuck in healing, rather than just passing through.